### PR TITLE
bugfix: support pp when enable mtp3

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -602,9 +602,16 @@ class SpeculativeConfig:
                     )
                 )
 
+                draft_pipeline_parallel_size = (
+                    1
+                    if self.uses_local_step3p5_mtp_drafter()
+                    else self.target_parallel_config.pipeline_parallel_size
+                )
                 self.draft_parallel_config = (
                     SpeculativeConfig.create_draft_parallel_config(
-                        self.target_parallel_config, self.draft_tensor_parallel_size
+                        self.target_parallel_config,
+                        self.draft_tensor_parallel_size,
+                        draft_pipeline_parallel_size,
                     )
                 )
         return self
@@ -740,13 +747,20 @@ class SpeculativeConfig:
     def create_draft_parallel_config(
         target_parallel_config: ParallelConfig,
         speculative_draft_tensor_parallel_size: int,
+        draft_pipeline_parallel_size: int | None = None,
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
         This is mostly a copy of the target parallel config, except the tp_size.
+        Some draft models are loaded locally on the last target PP rank, so
+        their PP size can be overridden independently of the target model.
         """
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.pipeline_parallel_size,
+            pipeline_parallel_size=(
+                target_parallel_config.pipeline_parallel_size
+                if draft_pipeline_parallel_size is None
+                else draft_pipeline_parallel_size
+            ),
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,
@@ -849,6 +863,16 @@ class SpeculativeConfig:
 
     def uses_extract_hidden_states(self) -> bool:
         return self.method == "extract_hidden_states"
+
+    def uses_local_step3p5_mtp_drafter(self) -> bool:
+        if not (
+            self.method == "mtp"
+            and self.enable_multi_layers_mtp
+            and self.draft_model_config is not None
+        ):
+            return False
+        hf_text_config = getattr(self.draft_model_config, "hf_text_config", None)
+        return getattr(hf_text_config, "model_type", None) == "step3p5_mtp"
 
     def __repr__(self) -> str:
         method = self.method

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -85,9 +85,17 @@ class SpeculativeConfig:
     draft_tensor_parallel_size: int | None = Field(default=None, ge=1)
     """The degree of the tensor parallelism for the draft model. Can only be 1
     or the same as the target model's tensor parallel size."""
+    draft_pipeline_parallel_size: int | None = Field(default=None, ge=1)
+    """The degree of pipeline parallelism for the draft model.
+
+    Defaults to the target model's pipeline parallel size. Set this to 1 to
+    run the drafter locally on the last target PP stage."""
     tensor_parallel_size: int | None = None
     """Users should pass "draft_tensor_parallel_size". This parameter's purpose is to
     warn users when they mistakenly provide the wrong argument."""
+    pipeline_parallel_size: int | None = None
+    """Users should pass "draft_pipeline_parallel_size". This parameter's
+    purpose is to warn users when they mistakenly provide the wrong argument."""
 
     # Draft model configuration
     quantization: me_quant.QuantizationMethods | None = None
@@ -602,16 +610,17 @@ class SpeculativeConfig:
                     )
                 )
 
-                draft_pipeline_parallel_size = (
-                    1
-                    if self.uses_local_step3p5_mtp_drafter()
-                    else self.target_parallel_config.pipeline_parallel_size
+                self.draft_pipeline_parallel_size = (
+                    SpeculativeConfig._verify_and_get_draft_pp(
+                        self.target_parallel_config,
+                        self.draft_pipeline_parallel_size,
+                    )
                 )
                 self.draft_parallel_config = (
                     SpeculativeConfig.create_draft_parallel_config(
                         self.target_parallel_config,
                         self.draft_tensor_parallel_size,
-                        draft_pipeline_parallel_size,
+                        self.draft_pipeline_parallel_size,
                     )
                 )
         return self
@@ -725,6 +734,30 @@ class SpeculativeConfig:
             )
         return speculative_draft_tensor_parallel_size
 
+    @staticmethod
+    def _verify_and_get_draft_pp(
+        target_parallel_config: ParallelConfig,
+        speculative_draft_pipeline_parallel_size: int | None,
+    ) -> int:
+        """
+        Verifies and adjusts the pipeline parallel size for a draft model
+        specified using speculative_draft_pipeline_parallel_size.
+        """
+        if speculative_draft_pipeline_parallel_size is None:
+            return target_parallel_config.pipeline_parallel_size
+
+        if speculative_draft_pipeline_parallel_size not in (
+            1,
+            target_parallel_config.pipeline_parallel_size,
+        ):
+            raise ValueError(
+                f"{speculative_draft_pipeline_parallel_size=} cannot be "
+                "other value than 1 or target model "
+                f"pipeline_parallel_size="
+                f"{target_parallel_config.pipeline_parallel_size}"
+            )
+        return speculative_draft_pipeline_parallel_size
+
     def update_arch_(self):
         """
         EagleConfig and ExtractHiddenStatesConfig update architectures, so update all
@@ -747,20 +780,15 @@ class SpeculativeConfig:
     def create_draft_parallel_config(
         target_parallel_config: ParallelConfig,
         speculative_draft_tensor_parallel_size: int,
-        draft_pipeline_parallel_size: int | None = None,
+        speculative_draft_pipeline_parallel_size: int,
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
-        This is mostly a copy of the target parallel config, except the tp_size.
-        Some draft models are loaded locally on the last target PP rank, so
-        their PP size can be overridden independently of the target model.
+        This is mostly a copy of the target parallel config, except the tp/pp
+        sizes used by the draft model.
         """
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=(
-                target_parallel_config.pipeline_parallel_size
-                if draft_pipeline_parallel_size is None
-                else draft_pipeline_parallel_size
-            ),
+            pipeline_parallel_size=speculative_draft_pipeline_parallel_size,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
             distributed_executor_backend=target_parallel_config.distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.max_parallel_loading_workers,
@@ -777,6 +805,12 @@ class SpeculativeConfig:
             raise ValueError(
                 "'tensor_parallel_size' is not a valid argument in the "
                 "speculative_config. Please pass 'draft_tensor_parallel_size' instead."
+            )
+        if self.pipeline_parallel_size is not None:
+            raise ValueError(
+                "'pipeline_parallel_size' is not a valid argument in the "
+                "speculative_config. Please pass "
+                "'draft_pipeline_parallel_size' instead."
             )
 
         if self.num_speculative_tokens is None:
@@ -864,15 +898,47 @@ class SpeculativeConfig:
     def uses_extract_hidden_states(self) -> bool:
         return self.method == "extract_hidden_states"
 
-    def uses_local_step3p5_mtp_drafter(self) -> bool:
-        if not (
-            self.method == "mtp"
-            and self.enable_multi_layers_mtp
-            and self.draft_model_config is not None
-        ):
+    def needs_partial_pp_draft_remap(
+        self, target_parallel_config: ParallelConfig
+    ) -> bool:
+        if self.draft_parallel_config is None:
             return False
-        hf_text_config = getattr(self.draft_model_config, "hf_text_config", None)
-        return getattr(hf_text_config, "model_type", None) == "step3p5_mtp"
+        return (
+            target_parallel_config.pipeline_parallel_size
+            > self.draft_parallel_config.pipeline_parallel_size
+        )
+
+    def resolve_partial_pp_draft_rank(self, target_parallel_config: ParallelConfig) -> int:
+        if not self.needs_partial_pp_draft_remap(target_parallel_config):
+            return target_parallel_config.rank
+
+        assert self.draft_parallel_config is not None
+        draft_pp = self.draft_parallel_config.pipeline_parallel_size
+        if draft_pp != 1:
+            raise ValueError(
+                "Partial pp drafter rank remapping only supports "
+                "draft_pipeline_parallel_size=1 when target PP is larger."
+            )
+
+        target_tp = target_parallel_config.tensor_parallel_size
+        draft_tp = self.draft_parallel_config.tensor_parallel_size
+        if draft_tp != target_tp:
+            raise ValueError(
+                "Partial pp drafter rank remapping requires "
+                "draft_tensor_parallel_size to equal target tensor_parallel_size. "
+                f"Got draft_tp={draft_tp}, target_tp={target_tp}."
+            )
+
+        target_pp = target_parallel_config.pipeline_parallel_size
+        target_rank = target_parallel_config.rank
+        target_pp_rank = target_rank // target_tp
+        target_tp_rank = target_rank % target_tp
+        if target_pp_rank != target_pp - 1:
+            raise ValueError(
+                "Partial pp drafter should only run on the last "
+                f"pipeline stage, but got pp rank {target_pp_rank} / {target_pp}"
+            )
+        return target_tp_rank
 
     def __repr__(self) -> str:
         method = self.method

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -901,6 +901,7 @@ class SpeculativeConfig:
     def needs_partial_pp_draft_remap(
         self, target_parallel_config: ParallelConfig
     ) -> bool:
+        """Whether draft PP is smaller than target PP and needs rank remap."""
         if self.draft_parallel_config is None:
             return False
         return (
@@ -908,7 +909,14 @@ class SpeculativeConfig:
             > self.draft_parallel_config.pipeline_parallel_size
         )
 
-    def resolve_partial_pp_draft_rank(self, target_parallel_config: ParallelConfig) -> int:
+    def resolve_partial_pp_draft_rank(
+        self, target_parallel_config: ParallelConfig
+    ) -> int:
+        """Map a target rank to the local draft rank for partial-PP drafting.
+
+        Currently this only supports running the draft model with `draft_pp=1`
+        on the last target PP stage.
+        """
         if not self.needs_partial_pp_draft_remap(target_parallel_config):
             return target_parallel_config.rank
 

--- a/vllm/model_executor/models/step3p5_mtp.py
+++ b/vllm/model_executor/models/step3p5_mtp.py
@@ -19,6 +19,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
 
+from .interfaces import SupportsPP
 from .step3p5 import Step3p5DecoderLayer, get_spec_layer_idx_from_weight_name
 from .utils import maybe_prefix
 
@@ -144,7 +145,7 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         return self.embed_tokens(input_ids)
 
 
-class Step3p5MTP(nn.Module):
+class Step3p5MTP(nn.Module, SupportsPP):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.config = vllm_config.model_config.hf_config

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -390,6 +390,21 @@ class Scheduler(SchedulerInterface):
                 num_new_tokens, self.max_model_len - 1 - request.num_computed_tokens
             )
 
+            if self.use_pp and request.spec_token_ids:
+                logger.error(
+                    "PP_SPEC schedule req=%s num_tokens=%d num_tokens_with_spec=%d "
+                    "num_computed=%d placeholders=%d spec_len=%d num_new_tokens=%d "
+                    "spec_tokens=%s",
+                    request.request_id,
+                    request.num_tokens,
+                    request.num_tokens_with_spec,
+                    request.num_computed_tokens,
+                    request.num_output_placeholders,
+                    len(request.spec_token_ids),
+                    num_new_tokens,
+                    request.spec_token_ids,
+                )
+
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
             external_load_encoder_input: list[int] = []
@@ -1044,6 +1059,17 @@ class Scheduler(SchedulerInterface):
                     req.num_computed_tokens : req.num_computed_tokens + num_tokens
                 ]
                 new_token_ids.append(token_ids)
+                if spec_decode_tokens.get(req_id) or token_ids:
+                    logger.error(
+                        "PP_SPEC cached req=%s num_scheduled=%d spec_len=%d "
+                        "num_computed=%d num_tokens=%d new_token_ids=%s",
+                        req_id,
+                        num_scheduled_tokens[req_id],
+                        len(spec_decode_tokens.get(req_id, ())),
+                        req.num_computed_tokens,
+                        req.num_tokens,
+                        token_ids,
+                    )
             scheduled_in_prev_step = req_id in self.prev_step_scheduled_req_ids
             if idx >= num_running_reqs:
                 assert not scheduled_in_prev_step
@@ -1321,6 +1347,17 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
+            if self.use_pp and (scheduled_spec_token_ids or generated_token_ids):
+                logger.error(
+                    "PP_SPEC output_before req=%s generated=%s scheduled_spec=%s "
+                    "num_tokens=%d num_computed=%d placeholders=%d",
+                    req_id,
+                    generated_token_ids,
+                    scheduled_spec_token_ids,
+                    request.num_tokens,
+                    request.num_computed_tokens,
+                    request.num_output_placeholders,
+                )
             if scheduled_spec_token_ids and generated_token_ids:
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_accepted = len(generated_token_ids) - 1
@@ -1356,6 +1393,17 @@ class Scheduler(SchedulerInterface):
                 new_token_ids, stopped = self._update_request_with_output(
                     request, new_token_ids
                 )
+                if self.use_pp:
+                    logger.error(
+                        "PP_SPEC output_after req=%s new_token_ids=%s num_tokens=%d "
+                        "num_computed=%d placeholders=%d stopped=%s",
+                        req_id,
+                        new_token_ids,
+                        request.num_tokens,
+                        request.num_computed_tokens,
+                        request.num_output_placeholders,
+                        stopped,
+                    )
             elif request.pooling_params and pooler_output is not None:
                 # Pooling stops as soon as there is output.
                 request.status = RequestStatus.FINISHED_STOPPED

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -390,21 +390,6 @@ class Scheduler(SchedulerInterface):
                 num_new_tokens, self.max_model_len - 1 - request.num_computed_tokens
             )
 
-            if self.use_pp and request.spec_token_ids:
-                logger.error(
-                    "PP_SPEC schedule req=%s num_tokens=%d num_tokens_with_spec=%d "
-                    "num_computed=%d placeholders=%d spec_len=%d num_new_tokens=%d "
-                    "spec_tokens=%s",
-                    request.request_id,
-                    request.num_tokens,
-                    request.num_tokens_with_spec,
-                    request.num_computed_tokens,
-                    request.num_output_placeholders,
-                    len(request.spec_token_ids),
-                    num_new_tokens,
-                    request.spec_token_ids,
-                )
-
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
             external_load_encoder_input: list[int] = []
@@ -1059,17 +1044,6 @@ class Scheduler(SchedulerInterface):
                     req.num_computed_tokens : req.num_computed_tokens + num_tokens
                 ]
                 new_token_ids.append(token_ids)
-                if spec_decode_tokens.get(req_id) or token_ids:
-                    logger.error(
-                        "PP_SPEC cached req=%s num_scheduled=%d spec_len=%d "
-                        "num_computed=%d num_tokens=%d new_token_ids=%s",
-                        req_id,
-                        num_scheduled_tokens[req_id],
-                        len(spec_decode_tokens.get(req_id, ())),
-                        req.num_computed_tokens,
-                        req.num_tokens,
-                        token_ids,
-                    )
             scheduled_in_prev_step = req_id in self.prev_step_scheduled_req_ids
             if idx >= num_running_reqs:
                 assert not scheduled_in_prev_step
@@ -1347,17 +1321,6 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
-            if self.use_pp and (scheduled_spec_token_ids or generated_token_ids):
-                logger.error(
-                    "PP_SPEC output_before req=%s generated=%s scheduled_spec=%s "
-                    "num_tokens=%d num_computed=%d placeholders=%d",
-                    req_id,
-                    generated_token_ids,
-                    scheduled_spec_token_ids,
-                    request.num_tokens,
-                    request.num_computed_tokens,
-                    request.num_output_placeholders,
-                )
             if scheduled_spec_token_ids and generated_token_ids:
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_accepted = len(generated_token_ids) - 1
@@ -1393,17 +1356,6 @@ class Scheduler(SchedulerInterface):
                 new_token_ids, stopped = self._update_request_with_output(
                     request, new_token_ids
                 )
-                if self.use_pp:
-                    logger.error(
-                        "PP_SPEC output_after req=%s new_token_ids=%s num_tokens=%d "
-                        "num_computed=%d placeholders=%d stopped=%s",
-                        req_id,
-                        new_token_ids,
-                        request.num_tokens,
-                        request.num_computed_tokens,
-                        request.num_output_placeholders,
-                        stopped,
-                    )
             elif request.pooling_params and pooler_output is not None:
                 # Pooling stops as soon as there is output.
                 request.status = RequestStatus.FINISHED_STOPPED

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -42,6 +42,7 @@ from vllm.v1.spec_decode.utils import (
     PADDING_SLOT_ID,
     compute_new_slot_mapping,
     copy_and_expand_eagle_inputs_kernel,
+    create_vllm_config_for_draft_model,
     eagle_prepare_inputs_padded_kernel,
     eagle_prepare_next_token_padded_kernel,
     extend_all_queries_by_N,
@@ -65,6 +66,19 @@ class SpecDecodeBaseProposer:
         self.vllm_config = vllm_config
         assert vllm_config.speculative_config is not None
         self.speculative_config = vllm_config.speculative_config
+        self.use_local_step3p5_mtp_drafter = (
+            self.speculative_config.uses_local_step3p5_mtp_drafter()
+        )
+        self.draft_vllm_config = (
+            create_vllm_config_for_draft_model(vllm_config)
+            if self.use_local_step3p5_mtp_drafter
+            else vllm_config
+        )
+        self.runtime_vllm_config = (
+            self.draft_vllm_config
+            if self.use_local_step3p5_mtp_drafter
+            else self.vllm_config
+        )
         self.draft_model_config = self.speculative_config.draft_model_config
         self.method = self.speculative_config.method
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
@@ -119,13 +133,13 @@ class SpecDecodeBaseProposer:
             self._get_eagle3_use_aux_hidden_state_from_config()
         )
 
-        self.compilation_config = self.vllm_config.compilation_config
+        self.compilation_config = self.runtime_vllm_config.compilation_config
 
         # Cudagraph dispatcher for PIECEWISE-only dispatching in eagle.
         # Keys are initialized later via initialize_cudagraph_keys() called from
         # gpu_model_runner._check_and_update_cudagraph_mode after
         # adjust_cudagraph_sizes_for_spec_decode is called.
-        self.cudagraph_dispatcher = CudagraphDispatcher(self.vllm_config)
+        self.cudagraph_dispatcher = CudagraphDispatcher(self.runtime_vllm_config)
 
         # persistent buffers for cuda graph
         self.input_ids = torch.zeros(
@@ -493,7 +507,7 @@ class SpecDecodeBaseProposer:
 
             with set_forward_context(
                 per_layer_attn_metadata,
-                self.vllm_config,
+                self.runtime_vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -710,7 +724,7 @@ class SpecDecodeBaseProposer:
 
             with set_forward_context(
                 per_layer_attn_metadata,
-                self.vllm_config,
+                self.runtime_vllm_config,
                 num_tokens=input_batch_size,
                 num_tokens_across_dp=batch_size_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -1156,7 +1170,7 @@ class SpecDecodeBaseProposer:
             # Run the model.
             with set_forward_context(
                 per_layer_attn_metadata,
-                self.vllm_config,
+                self.runtime_vllm_config,
                 num_tokens=num_input_tokens,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
                 slot_mapping=self._get_slot_mapping(
@@ -1314,7 +1328,7 @@ class SpecDecodeBaseProposer:
 
         with set_model_tag("eagle_head"):
             model = get_model(
-                vllm_config=self.vllm_config,
+                vllm_config=self.draft_vllm_config,
                 model_config=self.speculative_config.draft_model_config,
                 load_config=self.speculative_config.draft_load_config,
             )
@@ -1332,7 +1346,7 @@ class SpecDecodeBaseProposer:
 
         # Find draft layers (attention layers added by draft model)
         all_attn_layers = get_layers_from_vllm_config(
-            self.vllm_config,
+            self.runtime_vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
         self._draft_attn_layer_names = (
@@ -1585,7 +1599,7 @@ class SpecDecodeBaseProposer:
 
             with set_forward_context(
                 None,
-                self.vllm_config,
+                self.runtime_vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -1656,7 +1670,7 @@ class SpecDecodeBaseProposer:
         Called from the model runner's initialize_metadata_builders.
         """
         all_attn_layers = get_layers_from_vllm_config(
-            self.vllm_config,
+            self.runtime_vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
 
@@ -1694,7 +1708,7 @@ class SpecDecodeBaseProposer:
                         kv_cache_group_id=self.kv_cache_gid,
                     )
                     attn_group.create_metadata_builders(
-                        self.vllm_config,
+                        self.runtime_vllm_config,
                         self.device,
                         kernel_block_size=kernel_block_size,
                     )
@@ -1719,11 +1733,11 @@ class SpecDecodeBaseProposer:
         # coordinate across ranks
         # TODO(Flechman): support DBO ubatching
         should_ubatch, num_tokens_across_dp = False, None
-        if self.vllm_config.parallel_config.data_parallel_size > 1:
+        if self.runtime_vllm_config.parallel_config.data_parallel_size > 1:
             should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
                 coordinate_batch_across_dp(
                     num_tokens_unpadded=num_tokens,
-                    parallel_config=self.vllm_config.parallel_config,
+                    parallel_config=self.runtime_vllm_config.parallel_config,
                     allow_microbatching=False,
                     num_tokens_padded=num_tokens_padded,
                     cudagraph_mode=cudagraph_mode.value,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -66,19 +66,7 @@ class SpecDecodeBaseProposer:
         self.vllm_config = vllm_config
         assert vllm_config.speculative_config is not None
         self.speculative_config = vllm_config.speculative_config
-        self.use_local_step3p5_mtp_drafter = (
-            self.speculative_config.uses_local_step3p5_mtp_drafter()
-        )
-        self.draft_vllm_config = (
-            create_vllm_config_for_draft_model(vllm_config)
-            if self.use_local_step3p5_mtp_drafter
-            else vllm_config
-        )
-        self.runtime_vllm_config = (
-            self.draft_vllm_config
-            if self.use_local_step3p5_mtp_drafter
-            else self.vllm_config
-        )
+        self.draft_vllm_config = create_vllm_config_for_draft_model(vllm_config)
         self.draft_model_config = self.speculative_config.draft_model_config
         self.method = self.speculative_config.method
         self.pass_hidden_states_to_model = pass_hidden_states_to_model
@@ -133,13 +121,13 @@ class SpecDecodeBaseProposer:
             self._get_eagle3_use_aux_hidden_state_from_config()
         )
 
-        self.compilation_config = self.runtime_vllm_config.compilation_config
+        self.compilation_config = self.draft_vllm_config.compilation_config
 
         # Cudagraph dispatcher for PIECEWISE-only dispatching in eagle.
         # Keys are initialized later via initialize_cudagraph_keys() called from
         # gpu_model_runner._check_and_update_cudagraph_mode after
         # adjust_cudagraph_sizes_for_spec_decode is called.
-        self.cudagraph_dispatcher = CudagraphDispatcher(self.runtime_vllm_config)
+        self.cudagraph_dispatcher = CudagraphDispatcher(self.draft_vllm_config)
 
         # persistent buffers for cuda graph
         self.input_ids = torch.zeros(
@@ -507,7 +495,7 @@ class SpecDecodeBaseProposer:
 
             with set_forward_context(
                 per_layer_attn_metadata,
-                self.runtime_vllm_config,
+                self.draft_vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -724,7 +712,7 @@ class SpecDecodeBaseProposer:
 
             with set_forward_context(
                 per_layer_attn_metadata,
-                self.runtime_vllm_config,
+                self.draft_vllm_config,
                 num_tokens=input_batch_size,
                 num_tokens_across_dp=batch_size_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -1170,7 +1158,7 @@ class SpecDecodeBaseProposer:
             # Run the model.
             with set_forward_context(
                 per_layer_attn_metadata,
-                self.runtime_vllm_config,
+                self.draft_vllm_config,
                 num_tokens=num_input_tokens,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
                 slot_mapping=self._get_slot_mapping(
@@ -1346,7 +1334,7 @@ class SpecDecodeBaseProposer:
 
         # Find draft layers (attention layers added by draft model)
         all_attn_layers = get_layers_from_vllm_config(
-            self.runtime_vllm_config,
+            self.draft_vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
         self._draft_attn_layer_names = (
@@ -1599,7 +1587,7 @@ class SpecDecodeBaseProposer:
 
             with set_forward_context(
                 None,
-                self.runtime_vllm_config,
+                self.draft_vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -1670,7 +1658,7 @@ class SpecDecodeBaseProposer:
         Called from the model runner's initialize_metadata_builders.
         """
         all_attn_layers = get_layers_from_vllm_config(
-            self.runtime_vllm_config,
+            self.draft_vllm_config,
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
 
@@ -1708,7 +1696,7 @@ class SpecDecodeBaseProposer:
                         kv_cache_group_id=self.kv_cache_gid,
                     )
                     attn_group.create_metadata_builders(
-                        self.runtime_vllm_config,
+                        self.draft_vllm_config,
                         self.device,
                         kernel_block_size=kernel_block_size,
                     )
@@ -1733,11 +1721,11 @@ class SpecDecodeBaseProposer:
         # coordinate across ranks
         # TODO(Flechman): support DBO ubatching
         should_ubatch, num_tokens_across_dp = False, None
-        if self.runtime_vllm_config.parallel_config.data_parallel_size > 1:
+        if self.draft_vllm_config.parallel_config.data_parallel_size > 1:
             should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
                 coordinate_batch_across_dp(
                     num_tokens_unpadded=num_tokens,
-                    parallel_config=self.runtime_vllm_config.parallel_config,
+                    parallel_config=self.draft_vllm_config.parallel_config,
                     allow_microbatching=False,
                     num_tokens_padded=num_tokens_padded,
                     cudagraph_mode=cudagraph_mode.value,

--- a/vllm/v1/spec_decode/multi_layer_eagle.py
+++ b/vllm/v1/spec_decode/multi_layer_eagle.py
@@ -16,6 +16,20 @@ from vllm.v1.spec_decode.metadata import MultiLayerEagleMetadata
 
 logger = init_logger(__name__)
 
+
+def _pp_debug_value(value: Any, limit: int = 32) -> Any:
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().tolist()
+    elif hasattr(value, "tolist"):
+        value = value.tolist()
+    elif isinstance(value, tuple):
+        value = list(value)
+
+    if isinstance(value, list) and len(value) > limit:
+        return value[:limit] + ["..."]
+    return value
+
+
 BLOCK_HIDDEN = 128
 BLOCK_TOKENS = 128
 
@@ -71,6 +85,7 @@ class MultiLayerEagleProposer(EagleProposer):
             start_token_pos,
         )
         shift = torch.clamp(shift, min=0)
+        raw_shift = shift.clone()
 
         # Metadata updates (matches the original reference implementation).
         token_indices_to_sample.add_(shift)
@@ -93,6 +108,27 @@ class MultiLayerEagleProposer(EagleProposer):
 
         cached_lens = multi_layer_eagle_metadata.cached_len
         shift = torch.minimum(shift, cached_lens)
+        if self.vllm_config.parallel_config.pipeline_parallel_size > 1:
+            logger.error(
+                "PP_SPEC eagle_adjust batch=%d query_start_loc=%s "
+                "token_indices_to_sample=%s start_indices=%s end_indices=%s "
+                "start_positions=%s raw_shift=%s clipped_shift=%s "
+                "cached_len=%s seq_lens=%s slot_mapping=%s "
+                "target_token_ids=%s target_positions=%s",
+                batch_size,
+                _pp_debug_value(common_attn_metadata.query_start_loc_cpu),
+                _pp_debug_value(token_indices_to_sample),
+                _pp_debug_value(start_token_indices),
+                _pp_debug_value(end_token_indices),
+                _pp_debug_value(start_token_pos),
+                _pp_debug_value(raw_shift),
+                _pp_debug_value(shift),
+                _pp_debug_value(cached_lens),
+                _pp_debug_value(common_attn_metadata.seq_lens),
+                _pp_debug_value(slot_mapping),
+                _pp_debug_value(target_token_ids),
+                _pp_debug_value(target_positions),
+            )
 
         _multi_layer_eagle_shift_and_cache(
             batch_size=batch_size,
@@ -203,7 +239,7 @@ class MultiLayerEagleProposer(EagleProposer):
         for fwd_idx in range(self.layer_num):
             with set_forward_context(
                 None,
-                self.vllm_config,
+                self.runtime_vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
@@ -265,6 +301,8 @@ def _multi_layer_eagle_shift_and_cache(
     if src_slot_mapping.data_ptr() == dst_slot_mapping.data_ptr():
         src_slot_mapping = src_slot_mapping.clone()
 
+    cached_lens_before = cached_lens.clone()
+
     # Cache extraction for the next call.
     store_start = torch.maximum(
         start_token_indices,
@@ -287,6 +325,25 @@ def _multi_layer_eagle_shift_and_cache(
         .item()
     )
     num_blocks = max(1, (max_window_len + BLOCK_TOKENS - 1) // BLOCK_TOKENS)
+
+    logger.error(
+        "PP_SPEC eagle_cache_before batch=%d query_start_loc=%s "
+        "start_indices=%s end_indices=%s token_indices_to_sample=%s "
+        "shift=%s cached_lens_before=%s store_start=%s store_lens=%s "
+        "src_token_ids=%s src_positions=%s src_slot_mapping=%s",
+        batch_size,
+        _pp_debug_value(common_attn_metadata.query_start_loc_cpu),
+        _pp_debug_value(start_token_indices),
+        _pp_debug_value(end_token_indices),
+        _pp_debug_value(token_indices_to_sample),
+        _pp_debug_value(shift),
+        _pp_debug_value(cached_lens_before),
+        _pp_debug_value(store_start),
+        _pp_debug_value(store_lens),
+        _pp_debug_value(src_token_ids),
+        _pp_debug_value(src_positions),
+        _pp_debug_value(src_slot_mapping),
+    )
 
     _shift_and_gather_cache_1d_kernel[(batch_size, num_blocks)](
         src_token_ids,
@@ -357,6 +414,19 @@ def _multi_layer_eagle_shift_and_cache(
     )
 
     cached_lens.copy_(store_lens)
+    logger.error(
+        "PP_SPEC eagle_cache_after batch=%d cached_lens=%s "
+        "cached_token_ids=%s cached_slot_mappings=%s cached_positions=%s "
+        "dst_token_ids=%s dst_positions=%s dst_slot_mapping=%s",
+        batch_size,
+        _pp_debug_value(cached_lens),
+        _pp_debug_value(cached_prev_token_ids),
+        _pp_debug_value(cached_slot_mappings),
+        _pp_debug_value(cached_prev_positions),
+        _pp_debug_value(dst_token_ids),
+        _pp_debug_value(dst_positions),
+        _pp_debug_value(dst_slot_mapping),
+    )
     return
 
 

--- a/vllm/v1/spec_decode/multi_layer_eagle.py
+++ b/vllm/v1/spec_decode/multi_layer_eagle.py
@@ -6,28 +6,12 @@ import torch
 
 from vllm.config import VllmConfig
 from vllm.forward_context import set_forward_context
-from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.metadata import MultiLayerEagleMetadata
-
-logger = init_logger(__name__)
-
-
-def _pp_debug_value(value: Any, limit: int = 32) -> Any:
-    if isinstance(value, torch.Tensor):
-        value = value.detach().cpu().tolist()
-    elif hasattr(value, "tolist"):
-        value = value.tolist()
-    elif isinstance(value, tuple):
-        value = list(value)
-
-    if isinstance(value, list) and len(value) > limit:
-        return value[:limit] + ["..."]
-    return value
 
 
 BLOCK_HIDDEN = 128
@@ -85,7 +69,6 @@ class MultiLayerEagleProposer(EagleProposer):
             start_token_pos,
         )
         shift = torch.clamp(shift, min=0)
-        raw_shift = shift.clone()
 
         # Metadata updates (matches the original reference implementation).
         token_indices_to_sample.add_(shift)
@@ -108,27 +91,6 @@ class MultiLayerEagleProposer(EagleProposer):
 
         cached_lens = multi_layer_eagle_metadata.cached_len
         shift = torch.minimum(shift, cached_lens)
-        if self.vllm_config.parallel_config.pipeline_parallel_size > 1:
-            logger.error(
-                "PP_SPEC eagle_adjust batch=%d query_start_loc=%s "
-                "token_indices_to_sample=%s start_indices=%s end_indices=%s "
-                "start_positions=%s raw_shift=%s clipped_shift=%s "
-                "cached_len=%s seq_lens=%s slot_mapping=%s "
-                "target_token_ids=%s target_positions=%s",
-                batch_size,
-                _pp_debug_value(common_attn_metadata.query_start_loc_cpu),
-                _pp_debug_value(token_indices_to_sample),
-                _pp_debug_value(start_token_indices),
-                _pp_debug_value(end_token_indices),
-                _pp_debug_value(start_token_pos),
-                _pp_debug_value(raw_shift),
-                _pp_debug_value(shift),
-                _pp_debug_value(cached_lens),
-                _pp_debug_value(common_attn_metadata.seq_lens),
-                _pp_debug_value(slot_mapping),
-                _pp_debug_value(target_token_ids),
-                _pp_debug_value(target_positions),
-            )
 
         _multi_layer_eagle_shift_and_cache(
             batch_size=batch_size,
@@ -301,8 +263,6 @@ def _multi_layer_eagle_shift_and_cache(
     if src_slot_mapping.data_ptr() == dst_slot_mapping.data_ptr():
         src_slot_mapping = src_slot_mapping.clone()
 
-    cached_lens_before = cached_lens.clone()
-
     # Cache extraction for the next call.
     store_start = torch.maximum(
         start_token_indices,
@@ -325,25 +285,6 @@ def _multi_layer_eagle_shift_and_cache(
         .item()
     )
     num_blocks = max(1, (max_window_len + BLOCK_TOKENS - 1) // BLOCK_TOKENS)
-
-    logger.error(
-        "PP_SPEC eagle_cache_before batch=%d query_start_loc=%s "
-        "start_indices=%s end_indices=%s token_indices_to_sample=%s "
-        "shift=%s cached_lens_before=%s store_start=%s store_lens=%s "
-        "src_token_ids=%s src_positions=%s src_slot_mapping=%s",
-        batch_size,
-        _pp_debug_value(common_attn_metadata.query_start_loc_cpu),
-        _pp_debug_value(start_token_indices),
-        _pp_debug_value(end_token_indices),
-        _pp_debug_value(token_indices_to_sample),
-        _pp_debug_value(shift),
-        _pp_debug_value(cached_lens_before),
-        _pp_debug_value(store_start),
-        _pp_debug_value(store_lens),
-        _pp_debug_value(src_token_ids),
-        _pp_debug_value(src_positions),
-        _pp_debug_value(src_slot_mapping),
-    )
 
     _shift_and_gather_cache_1d_kernel[(batch_size, num_blocks)](
         src_token_ids,
@@ -414,19 +355,6 @@ def _multi_layer_eagle_shift_and_cache(
     )
 
     cached_lens.copy_(store_lens)
-    logger.error(
-        "PP_SPEC eagle_cache_after batch=%d cached_lens=%s "
-        "cached_token_ids=%s cached_slot_mappings=%s cached_positions=%s "
-        "dst_token_ids=%s dst_positions=%s dst_slot_mapping=%s",
-        batch_size,
-        _pp_debug_value(cached_lens),
-        _pp_debug_value(cached_prev_token_ids),
-        _pp_debug_value(cached_slot_mappings),
-        _pp_debug_value(cached_prev_positions),
-        _pp_debug_value(dst_token_ids),
-        _pp_debug_value(dst_positions),
-        _pp_debug_value(dst_slot_mapping),
-    )
     return
 
 

--- a/vllm/v1/spec_decode/multi_layer_eagle.py
+++ b/vllm/v1/spec_decode/multi_layer_eagle.py
@@ -13,7 +13,6 @@ from vllm.v1.attention.backend import (
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.metadata import MultiLayerEagleMetadata
 
-
 BLOCK_HIDDEN = 128
 BLOCK_TOKENS = 128
 

--- a/vllm/v1/spec_decode/multi_layer_eagle.py
+++ b/vllm/v1/spec_decode/multi_layer_eagle.py
@@ -201,7 +201,7 @@ class MultiLayerEagleProposer(EagleProposer):
         for fwd_idx in range(self.layer_num):
             with set_forward_context(
                 None,
-                self.runtime_vllm_config,
+                self.draft_vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -150,29 +150,29 @@ def compute_new_slot_mapping(
 
 
 def create_vllm_config_for_draft_model(
-    target_model_vllm_config: VllmConfig,
+    target_model_vllm_config: VllmConfig
 ) -> VllmConfig:
     """The vllm_config is configured for the target model, e.g.
     its quant_config and parallel_config. But the draft model is potentially
     quantized differently, and has potentially different tensor_parallel_size.
     This function creates a new vllm_config configured for the drafter.
     The vllm_config is useful when loading the draft model with get_model().
+
+    This helper returns the original target config for the common case and only
+    rewrites rank/parallel info when the drafter is configured to run locally
+    on the last target PP stage. This keeps runtime behavior unchanged for the
+    common case while still handling PP rank remapping.
     """
     old = target_model_vllm_config
     assert old.speculative_config is not None, "speculative_config is not set"
     old_spec_config = old.speculative_config
-    draft_rank = old.parallel_config.rank
-    if old_spec_config.uses_local_step3p5_mtp_drafter():
-        target_tp = old.parallel_config.tensor_parallel_size
-        target_pp = old.parallel_config.pipeline_parallel_size
-        target_rank = old.parallel_config.rank
-        target_pp_rank = target_rank // target_tp
-        target_tp_rank = target_rank % target_tp
-        assert target_pp_rank == target_pp - 1, (
-            "Local step3p5 MTP drafter should only run on the last "
-            f"pipeline stage, but got pp rank {target_pp_rank} / {target_pp}"
-        )
-        draft_rank = target_tp_rank
+    needs_rank_remap = old_spec_config.needs_partial_pp_draft_remap(
+        old.parallel_config
+    )
+    if not needs_rank_remap:
+        return old
+
+    draft_rank = old_spec_config.resolve_partial_pp_draft_rank(old.parallel_config)
 
     new_parallel_config = replace(
         old_spec_config.draft_parallel_config, rank=draft_rank

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -161,8 +161,21 @@ def create_vllm_config_for_draft_model(
     old = target_model_vllm_config
     assert old.speculative_config is not None, "speculative_config is not set"
     old_spec_config = old.speculative_config
+    draft_rank = old.parallel_config.rank
+    if old_spec_config.uses_local_step3p5_mtp_drafter():
+        target_tp = old.parallel_config.tensor_parallel_size
+        target_pp = old.parallel_config.pipeline_parallel_size
+        target_rank = old.parallel_config.rank
+        target_pp_rank = target_rank // target_tp
+        target_tp_rank = target_rank % target_tp
+        assert target_pp_rank == target_pp - 1, (
+            "Local step3p5 MTP drafter should only run on the last "
+            f"pipeline stage, but got pp rank {target_pp_rank} / {target_pp}"
+        )
+        draft_rank = target_tp_rank
+
     new_parallel_config = replace(
-        old_spec_config.draft_parallel_config, rank=old.parallel_config.rank
+        old_spec_config.draft_parallel_config, rank=draft_rank
     )
     new: VllmConfig = replace(
         old,

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -150,7 +150,7 @@ def compute_new_slot_mapping(
 
 
 def create_vllm_config_for_draft_model(
-    target_model_vllm_config: VllmConfig
+    target_model_vllm_config: VllmConfig,
 ) -> VllmConfig:
     """The vllm_config is configured for the target model, e.g.
     its quant_config and parallel_config. But the draft model is potentially
@@ -166,9 +166,7 @@ def create_vllm_config_for_draft_model(
     old = target_model_vllm_config
     assert old.speculative_config is not None, "speculative_config is not set"
     old_spec_config = old.speculative_config
-    needs_rank_remap = old_spec_config.needs_partial_pp_draft_remap(
-        old.parallel_config
-    )
+    needs_rank_remap = old_spec_config.needs_partial_pp_draft_remap(old.parallel_config)
     if not needs_rank_remap:
         return old
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1243,9 +1243,7 @@ class GPUModelRunner(
             return
 
         if self.cache_config.mamba_cache_mode == "align":
-            for i, num_tokens in enumerate(
-                accepted_tokens_cpu
-            ):
+            for i, num_tokens in enumerate(accepted_tokens_cpu):
                 self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
 
             mamba_utils.postprocess_mamba(
@@ -1339,9 +1337,12 @@ class GPUModelRunner(
             self.multi_layer_eagle_num, dtype=torch.int64, device=self.device
         )
 
-    def _sync_multi_layer_eagle_cache_to_requests(
-        self, req_ids: Iterable[str]
-    ) -> None:
+    def _sync_multi_layer_eagle_cache_to_requests(self, req_ids: Iterable[str]) -> None:
+        """Sync per-request cached tensors from InputBatch for unscheduled reqs.
+
+        Multi-layer EAGLE keeps per-request cached tensors that must stay
+        consistent with `input_batch` after condense/remove operations.
+        """
         if not self.enable_multi_layer_eagle:
             return
 
@@ -3845,10 +3846,10 @@ class GPUModelRunner(
         did_pp_prev_sampled_broadcast = False
         if self.use_async_scheduling:
             pp = get_pp_group()
+            # For external-launcher PP with broadcast_pp_output=True, logits
+            # computation already broadcasts PP outputs to all stages.
             need_pp_prev_sampled_broadcast = (
-                not self.broadcast_pp_output
-                and pp.world_size > 1
-                and pp.is_last_rank
+                not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank
             )
             if (
                 need_pp_prev_sampled_broadcast
@@ -4072,9 +4073,7 @@ class GPUModelRunner(
         assert draft_token_ids.dim() == 2 and draft_token_ids.shape[-1] == (
             self.num_spec_tokens
         ), "PP+async expects draft_token_ids to have shape [num_reqs, num_spec_tokens]"
-        torch.distributed.broadcast(
-            draft_token_ids, src=pp.rank, group=pp.device_group
-        )
+        torch.distributed.broadcast(draft_token_ids, src=pp.rank, group=pp.device_group)
 
     def _pp_receive_prev_sampled_token_ids_to_input_batch(self) -> None:
         """Receive sampled token ids broadcast from last PP stage"""
@@ -4132,11 +4131,13 @@ class GPUModelRunner(
     def _get_padded_draft_token_ids(
         self, num_reqs: int | None = None
     ) -> torch.Tensor | None:
+        """Return int32 draft ids padded to [num_reqs, num_spec_tokens]."""
         draft_token_ids = self._draft_token_ids
         if draft_token_ids is None:
             return None
         if torch.is_tensor(draft_token_ids):
-            return draft_token_ids.to(dtype=torch.int32)
+            # `input_ids` buffers are int32, so keep scatter source dtype aligned.
+            return cast(torch.Tensor, draft_token_ids).to(dtype=torch.int32)
 
         num_reqs = num_reqs if num_reqs is not None else len(draft_token_ids)
         padded_draft_token_ids = torch.zeros(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1986,7 +1986,11 @@ class GPUModelRunner(
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
 
-            if self.speculative_config and spec_decode_common_attn_metadata is None:
+            if (
+                self.speculative_config
+                and get_pp_group().is_last_rank
+                and spec_decode_common_attn_metadata is None
+            ):
                 if isinstance(self.drafter, EagleProposer):
                     if self.drafter.kv_cache_gid == kv_cache_gid:
                         spec_decode_common_attn_metadata = cm
@@ -5046,10 +5050,14 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if self.speculative_config and (
-                self.speculative_config.use_eagle()
-                or self.speculative_config.uses_draft_model()
-                or self.speculative_config.uses_extract_hidden_states()
+            if (
+                self.speculative_config
+                and get_pp_group().is_last_rank
+                and (
+                    self.speculative_config.use_eagle()
+                    or self.speculative_config.uses_draft_model()
+                    or self.speculative_config.uses_extract_hidden_states()
+                )
             ):
                 assert isinstance(
                     self.drafter,
@@ -5609,9 +5617,13 @@ class GPUModelRunner(
         self.calculate_reorder_batch_threshold()
 
         # Initialize drafter attention backend
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_draft_model()
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_draft_model()
+            )
         ):
             assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
             self.drafter.initialize_attn_backend(kv_cache_config, kernel_block_sizes)
@@ -5768,9 +5780,13 @@ class GPUModelRunner(
         )
 
         # Initialize drafter's cudagraph dispatcher if using spec decode.
-        if self.speculative_config and (
-            self.speculative_config.use_eagle()
-            or self.speculative_config.uses_extract_hidden_states()
+        if (
+            self.speculative_config
+            and get_pp_group().is_last_rank
+            and (
+                self.speculative_config.use_eagle()
+                or self.speculative_config.uses_extract_hidden_states()
+            )
         ):
             assert isinstance(self.drafter, EagleProposer | ExtractHiddenStatesProposer)
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
@@ -6142,6 +6158,7 @@ class GPUModelRunner(
 
         if (
             self.speculative_config
+            and get_pp_group().is_last_rank
             and self.speculative_config.uses_extract_hidden_states()
         ):
             assert isinstance(self.drafter, ExtractHiddenStatesProposer)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -201,19 +201,6 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def _pp_debug_value(value: Any, limit: int = 32) -> Any:
-    if isinstance(value, torch.Tensor):
-        value = value.detach().cpu().tolist()
-    elif isinstance(value, np.ndarray):
-        value = value.tolist()
-    elif isinstance(value, tuple):
-        value = list(value)
-
-    if isinstance(value, list) and len(value) > limit:
-        return value[:limit] + ["..."]
-    return value
-
-
 AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
 PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
@@ -444,8 +431,6 @@ class GPUModelRunner(
             self.parallel_config.distributed_executor_backend == "external_launcher"
             and len(get_pp_group().ranks) > 1
         )
-        self.use_pp = get_pp_group().world_size > 1
-
         # Model-related.
         self.num_query_heads = model_config.get_num_attention_heads(parallel_config)
         self.inputs_embeds_size = model_config.get_inputs_embeds_size()
@@ -1104,14 +1089,6 @@ class GPUModelRunner(
             self.input_batch.num_accepted_tokens_cpu[:num_prev_reqs] = (
                 valid_sampled_token_count[:num_prev_reqs]
             )
-            if self.use_pp:
-                pp = get_pp_group()
-                logger.error(
-                    "PP_SPEC accepted_sync rank=%d req_ids=%s num_accepted=%s",
-                    pp.rank,
-                    self.input_batch.req_ids[:num_prev_reqs],
-                    _pp_debug_value(valid_sampled_token_count[:num_prev_reqs]),
-                )
 
         for i, req_id in enumerate(req_data.req_ids):
             req_state = self.requests[req_id]
@@ -1261,17 +1238,6 @@ class GPUModelRunner(
         # rank as well instead of relying on a later hybrid-only path.
         accepted_tokens_cpu = accepted_tokens.cpu().numpy()
         self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted_tokens_cpu
-        if self.use_pp:
-            pp = get_pp_group()
-            logger.error(
-                "PP_SPEC accepted rank=%d is_last=%s req_ids=%s "
-                "output_token_ids=%s num_accepted=%s",
-                pp.rank,
-                pp.is_last_rank,
-                self.input_batch.req_ids[:num_reqs],
-                _pp_debug_value(output_token_ids),
-                _pp_debug_value(accepted_tokens_cpu),
-            )
 
         if not self.model_config.is_hybrid:
             return
@@ -1843,57 +1809,6 @@ class GPUModelRunner(
         else:
             multi_layer_eagle_metadata = None
 
-        if self.use_pp and use_spec_decode:
-            pp = get_pp_group()
-            req_ids = self.input_batch.req_ids[:num_reqs]
-            logger.error(
-                "PP_SPEC worker_prepare rank=%d is_last=%s req_ids=%s "
-                "num_scheduled=%s cu_num_tokens=%s query_start_loc=%s "
-                "seq_lens=%s num_computed=%s num_prompt=%s num_accepted=%s "
-                "spec_tokens=%s input_ids=%s positions=%s",
-                pp.rank,
-                pp.is_last_rank,
-                req_ids,
-                _pp_debug_value(num_scheduled_tokens),
-                _pp_debug_value(cu_num_tokens),
-                _pp_debug_value(self.query_start_loc.cpu[: num_reqs + 1]),
-                _pp_debug_value(self.seq_lens.cpu[:num_reqs]),
-                _pp_debug_value(self.input_batch.num_computed_tokens_cpu[:num_reqs]),
-                _pp_debug_value(self.input_batch.num_prompt_tokens[:num_reqs]),
-                _pp_debug_value(self.input_batch.num_accepted_tokens_cpu[:num_reqs]),
-                {
-                    req_id: scheduler_output.scheduled_spec_decode_tokens.get(
-                        req_id, []
-                    )
-                    for req_id in req_ids
-                },
-                _pp_debug_value(self.input_ids.cpu[:total_num_scheduled_tokens]),
-                _pp_debug_value(positions_np[:total_num_scheduled_tokens]),
-            )
-            if spec_decode_metadata is not None:
-                logger.error(
-                    "PP_SPEC worker_prepare_indices rank=%d logits_indices=%s "
-                    "target_logits=%s bonus_logits=%s draft_token_ids=%s",
-                    pp.rank,
-                    _pp_debug_value(spec_decode_metadata.logits_indices),
-                    _pp_debug_value(spec_decode_metadata.target_logits_indices),
-                    _pp_debug_value(spec_decode_metadata.bonus_logits_indices),
-                    _pp_debug_value(spec_decode_metadata.draft_token_ids),
-                )
-            if multi_layer_eagle_metadata is not None:
-                logger.error(
-                    "PP_SPEC worker_prepare_cache rank=%d cached_len=%s "
-                    "cached_token_ids=%s cached_slot_mappings=%s "
-                    "cached_positions=%s",
-                    pp.rank,
-                    _pp_debug_value(multi_layer_eagle_metadata.cached_len),
-                    _pp_debug_value(multi_layer_eagle_metadata.cached_token_ids),
-                    _pp_debug_value(
-                        multi_layer_eagle_metadata.cached_slot_mappings
-                    ),
-                    _pp_debug_value(multi_layer_eagle_metadata.cached_positions),
-                )
-
         # Hot-Swap lora model
         if self.lora_config:
             assert (
@@ -2453,42 +2368,6 @@ class GPUModelRunner(
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
         draft_token_ids = self.input_ids.gpu[logits_indices]
         draft_token_ids = draft_token_ids[target_logits_indices + 1]
-
-        if self.use_pp:
-            pp = get_pp_group()
-            req_ids = self.input_batch.req_ids[: len(num_draft_tokens)]
-            invalid_req_indices = np.flatnonzero(
-                cu_num_scheduled_tokens < num_sampled_tokens
-            ).tolist()
-            if invalid_req_indices:
-                logger.error(
-                    "PP_SPEC underflow rank=%d is_last=%s bad_req_ids=%s "
-                    "req_ids=%s cu_num_scheduled=%s num_draft=%s "
-                    "num_sampled=%s",
-                    pp.rank,
-                    pp.is_last_rank,
-                    [req_ids[idx] for idx in invalid_req_indices],
-                    req_ids,
-                    _pp_debug_value(cu_num_scheduled_tokens),
-                    _pp_debug_value(num_draft_tokens),
-                    _pp_debug_value(num_sampled_tokens),
-                )
-            logger.error(
-                "PP_SPEC metadata rank=%d is_last=%s req_ids=%s "
-                "cu_num_scheduled=%s num_draft=%s num_sampled=%s "
-                "logits_indices=%s target_logits=%s bonus_logits=%s "
-                "draft_token_ids=%s",
-                pp.rank,
-                pp.is_last_rank,
-                req_ids,
-                _pp_debug_value(cu_num_scheduled_tokens),
-                _pp_debug_value(num_draft_tokens),
-                _pp_debug_value(num_sampled_tokens),
-                _pp_debug_value(logits_indices),
-                _pp_debug_value(target_logits_indices),
-                _pp_debug_value(bonus_logits_indices),
-                _pp_debug_value(draft_token_ids),
-            )
 
         return SpecDecodeMetadata(
             draft_token_ids=draft_token_ids,
@@ -3949,38 +3828,6 @@ class GPUModelRunner(
         # Clear ephemeral state.
         self.execute_model_state = None
 
-        logger.error(f"spec_decode_metadata: {spec_decode_metadata}")
-        logger.error(f"multi_layer_eagle_metadata: {multi_layer_eagle_metadata}")
-        logger.error(f"spec_decode_common_attn_metadata: {spec_decode_common_attn_metadata}")
-        if self.use_pp and spec_decode_common_attn_metadata is not None:
-            pp = get_pp_group()
-            logger.error(
-                "PP_SPEC worker_execute rank=%d is_last=%s query_start_loc=%s "
-                "num_actual_tokens=%s seq_lens=%s slot_mapping=%s "
-                "num_computed=%s",
-                pp.rank,
-                pp.is_last_rank,
-                _pp_debug_value(spec_decode_common_attn_metadata.query_start_loc_cpu),
-                spec_decode_common_attn_metadata.num_actual_tokens,
-                _pp_debug_value(spec_decode_common_attn_metadata._seq_lens_cpu),
-                _pp_debug_value(spec_decode_common_attn_metadata.slot_mapping),
-                _pp_debug_value(
-                    spec_decode_common_attn_metadata._num_computed_tokens_cpu
-                ),
-            )
-        if self.use_pp and multi_layer_eagle_metadata is not None:
-            pp = get_pp_group()
-            logger.error(
-                "PP_SPEC worker_execute_cache rank=%d is_last=%s cached_len=%s "
-                "cached_token_ids=%s cached_slot_mappings=%s "
-                "cached_positions=%s",
-                pp.rank,
-                pp.is_last_rank,
-                _pp_debug_value(multi_layer_eagle_metadata.cached_len),
-                _pp_debug_value(multi_layer_eagle_metadata.cached_token_ids),
-                _pp_debug_value(multi_layer_eagle_metadata.cached_slot_mappings),
-                _pp_debug_value(multi_layer_eagle_metadata.cached_positions),
-            )
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
             apply_grammar_bitmask(
@@ -4034,7 +3881,6 @@ class GPUModelRunner(
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         spec_config = self.speculative_config
-        logger.info(f"spec_config: {spec_config}")
         propose_drafts_after_bookkeeping = False
         if spec_config is not None:
             input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -200,6 +200,20 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+
+def _pp_debug_value(value: Any, limit: int = 32) -> Any:
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().tolist()
+    elif isinstance(value, np.ndarray):
+        value = value.tolist()
+    elif isinstance(value, tuple):
+        value = list(value)
+
+    if isinstance(value, list) and len(value) > limit:
+        return value[:limit] + ["..."]
+    return value
+
+
 AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
 PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
@@ -430,6 +444,7 @@ class GPUModelRunner(
             self.parallel_config.distributed_executor_backend == "external_launcher"
             and len(get_pp_group().ranks) > 1
         )
+        self.use_pp = get_pp_group().world_size > 1
 
         # Model-related.
         self.num_query_heads = model_config.get_num_attention_heads(parallel_config)
@@ -731,6 +746,7 @@ class GPUModelRunner(
         # Cached outputs.
         self._draft_token_ids: list[list[int]] | torch.Tensor | None = None
         self._draft_token_req_ids: list[str] | None = None
+        self._pp_valid_sampled_token_count: torch.Tensor | None = None
         self.transfer_event = torch.Event()
         self.sampled_token_ids_pinned_cpu = torch.empty(
             (self.max_num_reqs, 1),
@@ -993,6 +1009,7 @@ class GPUModelRunner(
         # that they get cleared from the persistent batch before being re-scheduled
         # in the normal resumed request path.
         unscheduled_req_ids = cached_req_ids - (scheduled_req_ids - resumed_req_ids)
+        self._sync_multi_layer_eagle_cache_to_requests(unscheduled_req_ids)
         # NOTE(woosuk): The persistent batch optimization assumes that
         # consecutive batches contain mostly the same requests. If batches
         # have low request overlap (e.g., alternating between two distinct
@@ -1074,6 +1091,27 @@ class GPUModelRunner(
         # Wait until valid_sampled_tokens_count is copied to cpu,
         # then use it to update actual num_computed_tokens of each request.
         valid_sampled_token_count = self._get_valid_sampled_token_count()
+        if (
+            self.use_async_scheduling
+            and self.speculative_config is not None
+            and self.num_spec_tokens > 0
+            and not is_last_rank
+            and valid_sampled_token_count
+        ):
+            num_prev_reqs = min(
+                len(valid_sampled_token_count), self.input_batch.num_reqs
+            )
+            self.input_batch.num_accepted_tokens_cpu[:num_prev_reqs] = (
+                valid_sampled_token_count[:num_prev_reqs]
+            )
+            if self.use_pp:
+                pp = get_pp_group()
+                logger.error(
+                    "PP_SPEC accepted_sync rank=%d req_ids=%s num_accepted=%s",
+                    pp.rank,
+                    self.input_batch.req_ids[:num_prev_reqs],
+                    _pp_debug_value(valid_sampled_token_count[:num_prev_reqs]),
+                )
 
         for i, req_id in enumerate(req_data.req_ids):
             req_state = self.requests[req_id]
@@ -1206,38 +1244,41 @@ class GPUModelRunner(
     ) -> None:
         """Update the cached states after model execution.
 
-        This is used for MTP/EAGLE for hybrid models, as in linear attention,
-        only the last token's state is kept. In MTP/EAGLE, for draft tokens
-        the state are kept util we decide how many tokens are accepted for
-        each sequence, and a shifting is done during the next iteration
-        based on the number of accepted tokens.
+        This is used for speculative decoding bookkeeping. Hybrid models also
+        need the extra state maintenance below, while PP+async needs the host
+        copy of accepted-token counts to be refreshed for the next step.
         """
-        if not self.speculative_config or not self.model_config.is_hybrid:
+        if not self.speculative_config:
             return
 
         # Find the number of accepted tokens for each sequence.
         num_reqs = output_token_ids.size(0)
-        self.num_accepted_tokens.gpu[:num_reqs] = (
-            (
-                torch.cat(
-                    [
-                        output_token_ids,
-                        torch.full(
-                            (num_reqs, 1),
-                            -1,
-                            device=output_token_ids.device,
-                        ),
-                    ],
-                    dim=1,
-                )
-                == -1
+        accepted_tokens = self._get_valid_sampled_token_count_tensor(output_token_ids)
+        self.num_accepted_tokens.gpu[:num_reqs] = accepted_tokens
+
+        # `worker_prepare` reads the CPU-backed accepted counts when it builds
+        # the next speculative batch. Keep that copy in sync on the last PP
+        # rank as well instead of relying on a later hybrid-only path.
+        accepted_tokens_cpu = accepted_tokens.cpu().numpy()
+        self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted_tokens_cpu
+        if self.use_pp:
+            pp = get_pp_group()
+            logger.error(
+                "PP_SPEC accepted rank=%d is_last=%s req_ids=%s "
+                "output_token_ids=%s num_accepted=%s",
+                pp.rank,
+                pp.is_last_rank,
+                self.input_batch.req_ids[:num_reqs],
+                _pp_debug_value(output_token_ids),
+                _pp_debug_value(accepted_tokens_cpu),
             )
-            .int()
-            .argmax(-1)
-        )
+
+        if not self.model_config.is_hybrid:
+            return
+
         if self.cache_config.mamba_cache_mode == "align":
             for i, num_tokens in enumerate(
-                self.num_accepted_tokens.gpu[:num_reqs].cpu().numpy()
+                accepted_tokens_cpu
             ):
                 self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
 
@@ -1250,10 +1291,6 @@ class GPUModelRunner(
                 self.compilation_config.static_forward_context,
                 self.model.get_mamba_state_copy_func(),
                 self._get_mamba_copy_bufs(),
-            )
-        else:
-            self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
-                self.num_accepted_tokens.gpu[:num_reqs], non_blocking=True
             )
 
     def _update_streaming_request(
@@ -1335,6 +1372,38 @@ class GPUModelRunner(
         req_state.cached_slot_mappings = torch.zeros(
             self.multi_layer_eagle_num, dtype=torch.int64, device=self.device
         )
+
+    def _sync_multi_layer_eagle_cache_to_requests(
+        self, req_ids: Iterable[str]
+    ) -> None:
+        if not self.enable_multi_layer_eagle:
+            return
+
+        for req_id in req_ids:
+            req_index = self.input_batch.req_id_to_index.get(req_id)
+            req_state = self.requests.get(req_id)
+            if req_index is None or req_state is None:
+                continue
+
+            assert req_state.cached_len is not None
+            assert req_state.cached_token_ids is not None
+            assert req_state.cached_hidden_states is not None
+            assert req_state.cached_slot_mappings is not None
+            assert req_state.cached_positions is not None
+
+            req_state.cached_len[0] = self.input_batch.cached_len[req_index]
+            req_state.cached_token_ids.copy_(
+                self.input_batch.cached_token_ids[req_index]
+            )
+            req_state.cached_hidden_states.copy_(
+                self.input_batch.cached_hidden_states[req_index]
+            )
+            req_state.cached_slot_mappings.copy_(
+                self.input_batch.cached_slot_mappings[req_index]
+            )
+            req_state.cached_positions.copy_(
+                self.input_batch.cached_positions[req_index]
+            )
 
     def _extract_mm_kwargs(
         self,
@@ -1493,20 +1562,19 @@ class GPUModelRunner(
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
-        if self._draft_token_ids is None or not spec_flattened_indices:
+        if not spec_flattened_indices:
             return
 
-        assert isinstance(self._draft_token_ids, torch.Tensor)
+        draft_token_ids = self._get_padded_draft_token_ids(self.input_batch.num_reqs)
+        if draft_token_ids is None:
+            return
+
         draft_tokens_index_tensor = torch.tensor(
             spec_flattened_indices, dtype=torch.int64, pin_memory=self.pin_memory
         ).to(self.device, non_blocking=True)
         prev_draft_token_indices_tensor = torch.tensor(
             prev_draft_token_indices, dtype=torch.int64, pin_memory=self.pin_memory
         ).to(self.device, non_blocking=True)
-
-        # because input_ids dtype is torch.int32,
-        # so convert draft_token_ids to torch.int32 here.
-        draft_token_ids = self._draft_token_ids.to(dtype=torch.int32)
 
         self.input_ids.gpu.scatter_(
             dim=0,
@@ -1774,6 +1842,57 @@ class GPUModelRunner(
             )
         else:
             multi_layer_eagle_metadata = None
+
+        if self.use_pp and use_spec_decode:
+            pp = get_pp_group()
+            req_ids = self.input_batch.req_ids[:num_reqs]
+            logger.error(
+                "PP_SPEC worker_prepare rank=%d is_last=%s req_ids=%s "
+                "num_scheduled=%s cu_num_tokens=%s query_start_loc=%s "
+                "seq_lens=%s num_computed=%s num_prompt=%s num_accepted=%s "
+                "spec_tokens=%s input_ids=%s positions=%s",
+                pp.rank,
+                pp.is_last_rank,
+                req_ids,
+                _pp_debug_value(num_scheduled_tokens),
+                _pp_debug_value(cu_num_tokens),
+                _pp_debug_value(self.query_start_loc.cpu[: num_reqs + 1]),
+                _pp_debug_value(self.seq_lens.cpu[:num_reqs]),
+                _pp_debug_value(self.input_batch.num_computed_tokens_cpu[:num_reqs]),
+                _pp_debug_value(self.input_batch.num_prompt_tokens[:num_reqs]),
+                _pp_debug_value(self.input_batch.num_accepted_tokens_cpu[:num_reqs]),
+                {
+                    req_id: scheduler_output.scheduled_spec_decode_tokens.get(
+                        req_id, []
+                    )
+                    for req_id in req_ids
+                },
+                _pp_debug_value(self.input_ids.cpu[:total_num_scheduled_tokens]),
+                _pp_debug_value(positions_np[:total_num_scheduled_tokens]),
+            )
+            if spec_decode_metadata is not None:
+                logger.error(
+                    "PP_SPEC worker_prepare_indices rank=%d logits_indices=%s "
+                    "target_logits=%s bonus_logits=%s draft_token_ids=%s",
+                    pp.rank,
+                    _pp_debug_value(spec_decode_metadata.logits_indices),
+                    _pp_debug_value(spec_decode_metadata.target_logits_indices),
+                    _pp_debug_value(spec_decode_metadata.bonus_logits_indices),
+                    _pp_debug_value(spec_decode_metadata.draft_token_ids),
+                )
+            if multi_layer_eagle_metadata is not None:
+                logger.error(
+                    "PP_SPEC worker_prepare_cache rank=%d cached_len=%s "
+                    "cached_token_ids=%s cached_slot_mappings=%s "
+                    "cached_positions=%s",
+                    pp.rank,
+                    _pp_debug_value(multi_layer_eagle_metadata.cached_len),
+                    _pp_debug_value(multi_layer_eagle_metadata.cached_token_ids),
+                    _pp_debug_value(
+                        multi_layer_eagle_metadata.cached_slot_mappings
+                    ),
+                    _pp_debug_value(multi_layer_eagle_metadata.cached_positions),
+                )
 
         # Hot-Swap lora model
         if self.lora_config:
@@ -2334,6 +2453,42 @@ class GPUModelRunner(
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
         draft_token_ids = self.input_ids.gpu[logits_indices]
         draft_token_ids = draft_token_ids[target_logits_indices + 1]
+
+        if self.use_pp:
+            pp = get_pp_group()
+            req_ids = self.input_batch.req_ids[: len(num_draft_tokens)]
+            invalid_req_indices = np.flatnonzero(
+                cu_num_scheduled_tokens < num_sampled_tokens
+            ).tolist()
+            if invalid_req_indices:
+                logger.error(
+                    "PP_SPEC underflow rank=%d is_last=%s bad_req_ids=%s "
+                    "req_ids=%s cu_num_scheduled=%s num_draft=%s "
+                    "num_sampled=%s",
+                    pp.rank,
+                    pp.is_last_rank,
+                    [req_ids[idx] for idx in invalid_req_indices],
+                    req_ids,
+                    _pp_debug_value(cu_num_scheduled_tokens),
+                    _pp_debug_value(num_draft_tokens),
+                    _pp_debug_value(num_sampled_tokens),
+                )
+            logger.error(
+                "PP_SPEC metadata rank=%d is_last=%s req_ids=%s "
+                "cu_num_scheduled=%s num_draft=%s num_sampled=%s "
+                "logits_indices=%s target_logits=%s bonus_logits=%s "
+                "draft_token_ids=%s",
+                pp.rank,
+                pp.is_last_rank,
+                req_ids,
+                _pp_debug_value(cu_num_scheduled_tokens),
+                _pp_debug_value(num_draft_tokens),
+                _pp_debug_value(num_sampled_tokens),
+                _pp_debug_value(logits_indices),
+                _pp_debug_value(target_logits_indices),
+                _pp_debug_value(bonus_logits_indices),
+                _pp_debug_value(draft_token_ids),
+            )
 
         return SpecDecodeMetadata(
             draft_token_ids=draft_token_ids,
@@ -3762,6 +3917,9 @@ class GPUModelRunner(
             # receive sampled token ids from the last PP rank.
             if self.use_async_scheduling and get_pp_group().world_size > 1:
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
+                if self.speculative_config is not None and self.num_spec_tokens > 0:
+                    self._pp_receive_valid_sampled_token_count()
+                    self._pp_receive_draft_token_ids()
             if not kv_connector_output:
                 return None  # type: ignore[return-value]
 
@@ -3791,6 +3949,38 @@ class GPUModelRunner(
         # Clear ephemeral state.
         self.execute_model_state = None
 
+        logger.error(f"spec_decode_metadata: {spec_decode_metadata}")
+        logger.error(f"multi_layer_eagle_metadata: {multi_layer_eagle_metadata}")
+        logger.error(f"spec_decode_common_attn_metadata: {spec_decode_common_attn_metadata}")
+        if self.use_pp and spec_decode_common_attn_metadata is not None:
+            pp = get_pp_group()
+            logger.error(
+                "PP_SPEC worker_execute rank=%d is_last=%s query_start_loc=%s "
+                "num_actual_tokens=%s seq_lens=%s slot_mapping=%s "
+                "num_computed=%s",
+                pp.rank,
+                pp.is_last_rank,
+                _pp_debug_value(spec_decode_common_attn_metadata.query_start_loc_cpu),
+                spec_decode_common_attn_metadata.num_actual_tokens,
+                _pp_debug_value(spec_decode_common_attn_metadata._seq_lens_cpu),
+                _pp_debug_value(spec_decode_common_attn_metadata.slot_mapping),
+                _pp_debug_value(
+                    spec_decode_common_attn_metadata._num_computed_tokens_cpu
+                ),
+            )
+        if self.use_pp and multi_layer_eagle_metadata is not None:
+            pp = get_pp_group()
+            logger.error(
+                "PP_SPEC worker_execute_cache rank=%d is_last=%s cached_len=%s "
+                "cached_token_ids=%s cached_slot_mappings=%s "
+                "cached_positions=%s",
+                pp.rank,
+                pp.is_last_rank,
+                _pp_debug_value(multi_layer_eagle_metadata.cached_len),
+                _pp_debug_value(multi_layer_eagle_metadata.cached_token_ids),
+                _pp_debug_value(multi_layer_eagle_metadata.cached_slot_mappings),
+                _pp_debug_value(multi_layer_eagle_metadata.cached_positions),
+            )
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
             apply_grammar_bitmask(
@@ -3803,15 +3993,24 @@ class GPUModelRunner(
         self._update_states_after_model_execute(
             sampler_output.sampled_token_ids, scheduler_output
         )
+
+        need_pp_prev_sampled_broadcast = False
+        did_pp_prev_sampled_broadcast = False
         if self.use_async_scheduling:
             pp = get_pp_group()
-            # For torchrun external_launcher PP mode with broadcast_pp_output=True,
-            # PP outputs have been broadcasted to all ranks at logits computation.
-            # Therefore, here is no need to send sampled token ids again in this case.
-            if not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank:
+            need_pp_prev_sampled_broadcast = (
+                not self.broadcast_pp_output
+                and pp.world_size > 1
+                and pp.is_last_rank
+            )
+            if (
+                need_pp_prev_sampled_broadcast
+                and sampler_output.sampled_token_ids.shape[-1] == 1
+            ):
                 self._pp_broadcast_prev_sampled_token_ids(
                     sampler_output.sampled_token_ids
                 )
+                did_pp_prev_sampled_broadcast = True
 
         self._draft_token_ids = None
         self._draft_token_req_ids = None
@@ -3835,6 +4034,7 @@ class GPUModelRunner(
                 self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         spec_config = self.speculative_config
+        logger.info(f"spec_config: {spec_config}")
         propose_drafts_after_bookkeeping = False
         if spec_config is not None:
             input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
@@ -3901,6 +4101,35 @@ class GPUModelRunner(
             # ngram and other speculative decoding methods use the sampled
             # tokens on the CPU, so they are run after bookkeeping.
             propose_draft_token_ids(valid_sampled_token_ids)
+
+        if need_pp_prev_sampled_broadcast and not did_pp_prev_sampled_broadcast:
+            # In speculative decode, sampled_token_ids can be [num_reqs, num_spec + 1].
+            # Broadcast the reduced per-request next token ids prepared earlier.
+            prev_sampled_token_ids = self.input_batch.prev_sampled_token_ids
+            assert prev_sampled_token_ids is not None, (
+                "PP+async expects prev_sampled_token_ids before broadcast"
+            )
+            self._pp_broadcast_prev_sampled_token_ids(prev_sampled_token_ids)
+        if (
+            need_pp_prev_sampled_broadcast
+            and self.speculative_config is not None
+            and self.num_spec_tokens > 0
+        ):
+            valid_sampled_token_count = self._get_valid_sampled_token_count_tensor(
+                sampler_output.sampled_token_ids
+            )
+            self._pp_broadcast_valid_sampled_token_count(valid_sampled_token_count)
+
+            draft_token_ids = self._get_padded_draft_token_ids(
+                len(self.input_batch.req_ids)
+            )
+            if draft_token_ids is None:
+                draft_token_ids = torch.zeros(
+                    (len(self.input_batch.req_ids), self.num_spec_tokens),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+            self._pp_broadcast_draft_token_ids(draft_token_ids)
 
         # Clear KV connector metadata after draft model runs (if spec decode).
         # This was deferred from target model forward to allow draft model
@@ -3977,6 +4206,30 @@ class GPUModelRunner(
             sampled_token_ids, src=pp.rank, group=pp.device_group
         )
 
+    def _pp_broadcast_valid_sampled_token_count(
+        self, valid_sampled_token_count: torch.Tensor
+    ) -> None:
+        """Broadcast valid sampled-token counts from last PP stage."""
+        pp = get_pp_group()
+        assert pp.is_last_rank
+        assert valid_sampled_token_count.dim() == 1, (
+            "PP+async expects valid_sampled_token_count to have shape [num_reqs]"
+        )
+        torch.distributed.broadcast(
+            valid_sampled_token_count, src=pp.rank, group=pp.device_group
+        )
+
+    def _pp_broadcast_draft_token_ids(self, draft_token_ids: torch.Tensor) -> None:
+        """Broadcast drafted token ids from last PP stage."""
+        pp = get_pp_group()
+        assert pp.is_last_rank
+        assert draft_token_ids.dim() == 2 and draft_token_ids.shape[-1] == (
+            self.num_spec_tokens
+        ), "PP+async expects draft_token_ids to have shape [num_reqs, num_spec_tokens]"
+        torch.distributed.broadcast(
+            draft_token_ids, src=pp.rank, group=pp.device_group
+        )
+
     def _pp_receive_prev_sampled_token_ids_to_input_batch(self) -> None:
         """Receive sampled token ids broadcast from last PP stage"""
         pp = get_pp_group()
@@ -4002,11 +4255,55 @@ class GPUModelRunner(
                 req_state.output_token_ids.append(-1)
         self.input_batch.prev_req_id_to_index = prev_req_id_to_index
 
+    def _pp_receive_valid_sampled_token_count(self) -> None:
+        """Receive valid sampled-token counts broadcast from last PP stage."""
+        pp = get_pp_group()
+        assert not pp.is_last_rank
+        recv = torch.empty(
+            (self.input_batch.num_reqs,), dtype=torch.int32, device=self.device
+        )
+        torch.distributed.broadcast(recv, src=pp.last_rank, group=pp.device_group)
+        self._pp_valid_sampled_token_count = recv.cpu()
+
+    def _pp_receive_draft_token_ids(self) -> None:
+        """Receive drafted token ids broadcast from last PP stage."""
+        pp = get_pp_group()
+        assert not pp.is_last_rank
+        recv = torch.empty(
+            (self.input_batch.num_reqs, self.num_spec_tokens),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        torch.distributed.broadcast(recv, src=pp.last_rank, group=pp.device_group)
+        self._draft_token_ids = recv
+
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         if not self.num_spec_tokens or not self._draft_token_req_ids:
             return None
         draft_token_ids, req_ids = self._get_draft_token_ids_cpu()
         return DraftTokenIds(req_ids, draft_token_ids)
+
+    def _get_padded_draft_token_ids(
+        self, num_reqs: int | None = None
+    ) -> torch.Tensor | None:
+        draft_token_ids = self._draft_token_ids
+        if draft_token_ids is None:
+            return None
+        if torch.is_tensor(draft_token_ids):
+            return draft_token_ids.to(dtype=torch.int32)
+
+        num_reqs = num_reqs if num_reqs is not None else len(draft_token_ids)
+        padded_draft_token_ids = torch.zeros(
+            (num_reqs, self.num_spec_tokens), dtype=torch.int32, device=self.device
+        )
+        for req_idx, token_ids in enumerate(draft_token_ids[:num_reqs]):
+            if not token_ids:
+                continue
+            num_tokens = min(len(token_ids), self.num_spec_tokens)
+            padded_draft_token_ids[req_idx, :num_tokens] = torch.tensor(
+                token_ids[:num_tokens], dtype=torch.int32, device=self.device
+            )
+        return padded_draft_token_ids
 
     def _copy_draft_token_ids_to_cpu(
         self, scheduler_output: "SchedulerOutput", zeros_only: bool = False
@@ -4072,6 +4369,11 @@ class GPUModelRunner(
         self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
 
     def _get_valid_sampled_token_count(self) -> list[int]:
+        if self._pp_valid_sampled_token_count is not None:
+            counts = self._pp_valid_sampled_token_count.tolist()
+            self._pp_valid_sampled_token_count = None
+            return counts
+
         # Wait until valid_sampled_tokens_count is copied to cpu,
         prev_sampled_token_ids = self.input_batch.prev_sampled_token_ids
         sampled_count_event = self.valid_sampled_token_count_event
@@ -4082,6 +4384,31 @@ class GPUModelRunner(
         assert counts_cpu is not None
         sampled_count_event.synchronize()
         return counts_cpu[: prev_sampled_token_ids.shape[0]].tolist()
+
+    def _get_valid_sampled_token_count_tensor(
+        self, sampled_token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        num_reqs = sampled_token_ids.size(0)
+        return (
+            (
+                torch.cat(
+                    [
+                        sampled_token_ids,
+                        torch.full(
+                            (num_reqs, 1),
+                            -1,
+                            device=sampled_token_ids.device,
+                            dtype=sampled_token_ids.dtype,
+                        ),
+                    ],
+                    dim=1,
+                )
+                == -1
+            )
+            .int()
+            .argmax(-1)
+            .to(dtype=torch.int32)
+        )
 
     def propose_draft_token_ids(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Support pp when enable mtp3

1. drafter 设计上只在最后 PP rank 初始化
2. 新增 draft_vllm_config, 当 draft model 的并行策略和target model 并行策略不一致时，替换原来的 vllm_config, 让 drafter forward 相关逻辑（forward context、cudagraph、attn metadata builder）使用“draft 的并行配置”，而不是误用 target 的配置
3. 修复  PP 多 stage + async  + MTP3 场景下, 非 last pp group 状态错误的问题。

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

